### PR TITLE
fix evaluate_vqgan.py attempting to load nonexistent args

### DIFF
--- a/engiopt/vqgan/evaluate_vqgan.py
+++ b/engiopt/vqgan/evaluate_vqgan.py
@@ -84,8 +84,10 @@ if __name__ == "__main__":
             super().__init__("Failed to retrieve the run")
 
     run = artifact_transformer.logged_by()
-    if run is None or not hasattr(run, "config"):
+    if run is None:
         raise RunRetrievalError
+    run = api.run(f"{run.entity}/{run.project}/{run.id}")
+
     artifact_dir_cvqgan = artifact_cvqgan.download()
     artifact_dir_vqgan = artifact_vqgan.download()
     artifact_dir_transformer = artifact_transformer.download()

--- a/engiopt/vqgan/vqgan.py
+++ b/engiopt/vqgan/vqgan.py
@@ -680,8 +680,8 @@ if __name__ == "__main__":
     # Now we assume the dataset is of shape (N, C, H, W) and work from there
     image_channels = training_ds["optimal_upsampled"][:].shape[1]
     latent_size = args.image_size // (2 ** (len(args.encoder_channels) - 2))
-    conditions = problem.conditions_keys
 
+    conditions = problem.conditions_keys
     # Optionally drop condition columns that are constant like overhang_constraint in beams2d
     if args.drop_constant_conditions:
         training_ds, conditions = drop_constant(training_ds, conditions)
@@ -787,6 +787,8 @@ if __name__ == "__main__":
         wandb.define_metric("epoch_transformer", step_metric="transformer_step")
         if args.early_stopping:
             wandb.define_metric("transformer_val_loss", step_metric="transformer_step")
+        wandb.config["image_channels"] = image_channels
+        wandb.config["latent_size"] = latent_size
 
     vqgan = VQGAN(
         device=device,


### PR DESCRIPTION
Upon further testing I discovered there was a minor issue in the eval code after removing the previous `image_channels` and `latent_size` args. To address this I simply saved those variables as `wandb.config["image_channels"] = image_channels` and `wandb.config["latent_size"] = latent_size`. This also required a small change in the run-loading code of `evaluate_vqgan.py`.