### PR TITLE
Fix diffusion training and sampling issues

### DIFF
--- a/engiopt/diffusion_1d/diffusion_1d.py
+++ b/engiopt/diffusion_1d/diffusion_1d.py
@@ -48,6 +48,12 @@ class Normalizer:
         return x * (self.max_val - self.min_val + self.eps) + self.min_val
 
 
+def _prepare_diffusion_batch(designs: th.Tensor, design_normalizer: Normalizer) -> th.Tensor:
+    """Normalize designs and add the channel dimension expected by GaussianDiffusion1D."""
+    designs = design_normalizer.normalize(designs)
+    return designs.view(designs.size(0), 1, -1)
+
+
 def prepare_data(problem: Problem, padding_size: int, device: th.device) -> tuple[th.utils.data.TensorDataset, Normalizer]:
     """Prepares the data for the generator and discriminator.
 
@@ -182,7 +188,7 @@ if __name__ == "__main__":
     diffusion = GaussianDiffusion1D(
         model,
         seq_length=np.prod(design_shape),
-        auto_normalize=True,
+        auto_normalize=args.auto_norm,
     ).to(device)
 
     # Configure data loader
@@ -206,9 +212,7 @@ if __name__ == "__main__":
         for i, data in enumerate(dataloader):
             designs = data[0]
 
-            designs_flat = designs.view(designs.size(0), 1, -1)  # flattens designs to a batch of 1D tensors with 1 channel
-            # Normalize the designs
-            designs = design_normalizer.normalize(designs)
+            designs_flat = _prepare_diffusion_batch(designs, design_normalizer)
 
             # Learning
             optimizer.zero_grad()

--- a/engiopt/diffusion_1d/evaluate_diffusion_1d.py
+++ b/engiopt/diffusion_1d/evaluate_diffusion_1d.py
@@ -13,11 +13,11 @@ import numpy as np
 import pandas as pd
 import torch as th
 import tyro
+import wandb
 
 from engiopt import metrics
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.diffusion_1d.diffusion_1d import prepare_data
-import wandb
 
 
 @dataclasses.dataclass
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     diffusion = GaussianDiffusion1D(
         model,
         seq_length=np.prod(design_shape),
-        auto_normalize=True,
+        auto_normalize=run.config.get("auto_norm", True),
     ).to(device)
 
     diffusion.load_state_dict(ckpt["model"])

--- a/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
+++ b/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
@@ -68,7 +68,7 @@ class Args:
     sample_interval: int = 400
     """interval between image samples"""
 
-    num_timesteps: int = 250
+    num_timesteps: int = 1000
     """Number of timesteps in the diffusion schedule"""
     layers_per_block: int = 2
     """Layers per U-NET block"""
@@ -186,9 +186,12 @@ class DiffusionSampler:
         noise_pred: th.Tensor,
         x_noisy: th.Tensor,
         t: th.Tensor,
-        device: th.device = th.device("cpu"),  # noqa: B008
+        device: th.device | None = None,
     ) -> th.Tensor:
         """Takes an image, noise and step; returns denoised image."""
+        if device is None:
+            device = x_noisy.device
+
         betas_t = get_index_from_list(self.betas, t, x_noisy.shape).to(device)
         sqrt_one_minus_alphas_cumprod_t = get_index_from_list(self.sqrt_one_minus_alphas_cumprod, t, x_noisy.shape).to(
             device
@@ -196,9 +199,10 @@ class DiffusionSampler:
         sqrt_recip_alphas_t = get_index_from_list(self.sqrt_recip_alphas, t, x_noisy.shape).to(device)
         model_mean = sqrt_recip_alphas_t * (x_noisy - betas_t * noise_pred / sqrt_one_minus_alphas_cumprod_t)
         posterior_variance_t = get_index_from_list(self.posterior_variance, t, x_noisy.shape).to(device)
+        t_mask = ((t != 0).float().view(-1, *([1] * (len(x_noisy.shape) - 1)))).to(device)
 
         # mean + variance
-        return (model_mean + th.sqrt(posterior_variance_t) * noise_pred).to(device)
+        return (model_mean + th.sqrt(posterior_variance_t) * th.randn_like(x_noisy) * t_mask).to(device)
 
     def lossfn_builder(self) -> Callable[[th.Tensor, th.Tensor], th.Tensor]:
         """Returns the loss function for the diffusion model."""

--- a/engiopt/diffusion_2d_cond/evaluate_diffusion_2d_cond.py
+++ b/engiopt/diffusion_2d_cond/evaluate_diffusion_2d_cond.py
@@ -11,12 +11,12 @@ import numpy as np
 import pandas as pd
 import torch as th
 import tyro
+import wandb
 
 from engiopt import metrics
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.diffusion_2d_cond.diffusion_2d_cond import beta_schedule
 from engiopt.diffusion_2d_cond.diffusion_2d_cond import DiffusionSampler
-import wandb
 
 
 @dataclasses.dataclass

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for EngiOpt."""

--- a/tests/test_diffusion_fixes.py
+++ b/tests/test_diffusion_fixes.py
@@ -1,0 +1,67 @@
+"""Focused checks for diffusion training and sampling fixes."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_diffusion_1d_batch_is_normalized_before_forward() -> None:
+    """The 1D diffusion model should receive [0, 1] designs before auto-normalization."""
+    th = pytest.importorskip("torch")
+    diffusion_1d = pytest.importorskip("engiopt.diffusion_1d.diffusion_1d")
+
+    designs = th.tensor([[2.0, 4.0], [6.0, 8.0]])
+    normalizer = diffusion_1d.Normalizer(
+        min_val=th.tensor([2.0, 4.0]),
+        max_val=th.tensor([6.0, 8.0]),
+    )
+
+    batch = diffusion_1d._prepare_diffusion_batch(designs, normalizer)  # noqa: SLF001
+
+    expected_shape = (2, 1, 2)
+    assert batch.shape == expected_shape
+    assert th.allclose(batch.squeeze(1), th.tensor([[0.0, 0.0], [1.0, 1.0]]))
+
+
+def test_default_linear_schedule_reaches_nearly_pure_noise() -> None:
+    """The default noisiest training step should be close to the pure-noise sampling prior."""
+    th = pytest.importorskip("torch")
+    diffusion_2d = pytest.importorskip("engiopt.diffusion_2d_cond.diffusion_2d_cond")
+
+    betas = diffusion_2d.beta_schedule(
+        t=diffusion_2d.Args().num_timesteps,
+        start=1e-4,
+        end=0.02,
+        scale=1.0,
+        options={"cosine": False, "exp_biasing": False, "exp_bias_factor": 1},
+    )
+    terminal_signal = th.sqrt(th.cumprod(1.0 - betas, dim=0)[-1])
+
+    max_terminal_signal = 0.01
+    assert terminal_signal.item() < max_terminal_signal
+
+
+def test_diffusion_step_sample_uses_fresh_noise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The variance term should use random sampling noise, not the predicted epsilon."""
+    th = pytest.importorskip("torch")
+    diffusion_2d = pytest.importorskip("engiopt.diffusion_2d_cond.diffusion_2d_cond")
+
+    betas = diffusion_2d.beta_schedule(t=4, start=1e-4, end=0.02)
+    sampler = diffusion_2d.DiffusionSampler(t=4, betas=betas)
+    x_noisy = th.ones(2, 1, 2, 2)
+    noise_pred = th.full_like(x_noisy, 0.25)
+    t = th.tensor([1, 2], dtype=th.long)
+
+    monkeypatch.setattr(diffusion_2d.th, "randn_like", th.zeros_like)
+
+    actual = sampler.diffusion_step_sample(noise_pred, x_noisy, t)
+    betas_t = diffusion_2d.get_index_from_list(sampler.betas, t, x_noisy.shape)
+    sqrt_one_minus_alphas_cumprod_t = diffusion_2d.get_index_from_list(
+        sampler.sqrt_one_minus_alphas_cumprod,
+        t,
+        x_noisy.shape,
+    )
+    sqrt_recip_alphas_t = diffusion_2d.get_index_from_list(sampler.sqrt_recip_alphas, t, x_noisy.shape)
+    expected = sqrt_recip_alphas_t * (x_noisy - betas_t * noise_pred / sqrt_one_minus_alphas_cumprod_t)
+
+    assert th.allclose(actual, expected)


### PR DESCRIPTION
## Summary

I fixed the diffusion issues reported in #64, #65, and #66.

- I fixed the 1D diffusion training path so designs are normalized before being reshaped and passed into `GaussianDiffusion1D`.
- I wired the 1D `auto_norm` argument into both training and evaluation so restored runs use the saved normalization behavior.
- I changed the conditional 2D diffusion default from 250 to 1000 timesteps. With the existing linear beta schedule, 250 steps left `sqrt(alpha_bar_T) ~= 0.282`, while 1000 steps brings it to `~0.00635`, which better matches sampling from Gaussian noise.
- I fixed `DiffusionSampler.diffusion_step_sample` to use fresh Gaussian noise for the posterior variance term instead of reusing the predicted noise, and to avoid adding noise at `t=0`.
- I added focused regression tests for the 1D normalization path, the 2D schedule sanity check, and the sampler variance-noise behavior.

## Validation

I validated this in the `engibench` Conda environment after running the documented EngiOpt install flow (`pip install -e .`).

- `python -m pip check` passed with no broken requirements.
- `python -m pytest -q` passed (`3 passed`).
- `ruff check` passed on the changed diffusion files and tests.
- `ruff format --check` passed on the changed diffusion files and tests.
- `python -m compileall engiopt/diffusion_1d engiopt/diffusion_2d_cond tests` passed.
- I ran a 1D smoke check on real EngiBench `airfoil` data: one forward loss, backward pass, optimizer step, and sample all completed with finite values and nonzero gradients.
- I ran a 2D conditional smoke check on real EngiBench `beams2d` data: one forward loss, backward pass, optimizer step, terminal schedule check, and sampler step all completed with finite values and nonzero gradients.

## Notes

A full-repo `ruff check engiopt tests` still reports pre-existing import-order issues in unrelated files. I kept this PR scoped to the diffusion fixes and verified the touched files instead.

Fixes #64
Fixes #65
Fixes #66