### PR TITLE
Normalize 2D diffusion designs to DDPM sample scale

### DIFF
--- a/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
+++ b/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
@@ -25,6 +25,9 @@ from engiopt.reproducibility import seed_training
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+DIFFUSION_SAMPLE_MIN = -1.0
+DIFFUSION_SAMPLE_MAX = 1.0
+
 
 @dataclass
 class Args:
@@ -125,6 +128,27 @@ def get_index_from_list(vals: th.Tensor, t: th.Tensor, x_shape: tuple[int, ...])
     return out.reshape(batch_size, *((1,) * (len(x_shape) - 1))).to(t.device)
 
 
+def normalize_designs_to_diffusion_range(
+    designs: th.Tensor,
+    design_min: th.Tensor,
+    design_max: th.Tensor,
+) -> th.Tensor:
+    """Map designs from their observed training bounds to [-1, 1]."""
+    denom = th.clamp(design_max - design_min, min=th.finfo(designs.dtype).eps)
+    designs_01 = (designs - design_min) / denom
+    return designs_01 * (DIFFUSION_SAMPLE_MAX - DIFFUSION_SAMPLE_MIN) + DIFFUSION_SAMPLE_MIN
+
+
+def denormalize_designs_from_diffusion_range(
+    designs: th.Tensor,
+    design_min: th.Tensor,
+    design_max: th.Tensor,
+) -> th.Tensor:
+    """Map designs from [-1, 1] back to their original training-data scale."""
+    designs_01 = (designs - DIFFUSION_SAMPLE_MIN) / (DIFFUSION_SAMPLE_MAX - DIFFUSION_SAMPLE_MIN)
+    return designs_01 * (design_max - design_min) + design_min
+
+
 class DiffusionSampler:
     # Precompute the sqrt alphas and sqrt one minus alphas
     def __init__(self, t: int, betas: th.Tensor):
@@ -137,6 +161,22 @@ class DiffusionSampler:
         self.sqrt_alphas_cumprod = th.sqrt(self.alphas_cumprod)
         self.sqrt_one_minus_alphas_cumprod = th.sqrt(1.0 - self.alphas_cumprod)
         self.posterior_variance = self.betas * (1.0 - self.alphas_cumprod_prev) / (1.0 - self.alphas_cumprod)
+        self.posterior_mean_coef1 = self.betas * th.sqrt(self.alphas_cumprod_prev) / (1.0 - self.alphas_cumprod)
+        self.posterior_mean_coef2 = (1.0 - self.alphas_cumprod_prev) * th.sqrt(self.alphas) / (1.0 - self.alphas_cumprod)
+
+    def _posterior_mean(self, noise_pred: th.Tensor, x_noisy: th.Tensor, t: th.Tensor) -> th.Tensor:
+        sqrt_alphas_cumprod_t = get_index_from_list(self.sqrt_alphas_cumprod, t, x_noisy.shape)
+        sqrt_one_minus_alphas_cumprod_t = get_index_from_list(
+            self.sqrt_one_minus_alphas_cumprod,
+            t,
+            x_noisy.shape,
+        )
+        pred_original_sample = (x_noisy - sqrt_one_minus_alphas_cumprod_t * noise_pred) / sqrt_alphas_cumprod_t
+        pred_original_sample = pred_original_sample.clamp(DIFFUSION_SAMPLE_MIN, DIFFUSION_SAMPLE_MAX)
+
+        posterior_mean_coef1_t = get_index_from_list(self.posterior_mean_coef1, t, x_noisy.shape)
+        posterior_mean_coef2_t = get_index_from_list(self.posterior_mean_coef2, t, x_noisy.shape)
+        return posterior_mean_coef1_t * pred_original_sample + posterior_mean_coef2_t * x_noisy
 
     def forward_diffusion_sample(
         self,
@@ -192,12 +232,7 @@ class DiffusionSampler:
         if device is None:
             device = x_noisy.device
 
-        betas_t = get_index_from_list(self.betas, t, x_noisy.shape).to(device)
-        sqrt_one_minus_alphas_cumprod_t = get_index_from_list(self.sqrt_one_minus_alphas_cumprod, t, x_noisy.shape).to(
-            device
-        )
-        sqrt_recip_alphas_t = get_index_from_list(self.sqrt_recip_alphas, t, x_noisy.shape).to(device)
-        model_mean = sqrt_recip_alphas_t * (x_noisy - betas_t * noise_pred / sqrt_one_minus_alphas_cumprod_t)
+        model_mean = self._posterior_mean(noise_pred, x_noisy, t).to(device)
         posterior_variance_t = get_index_from_list(self.posterior_variance, t, x_noisy.shape).to(device)
         t_mask = ((t != 0).float().view(-1, *([1] * (len(x_noisy.shape) - 1)))).to(device)
 
@@ -226,13 +261,9 @@ class DiffusionSampler:
         """
         model.eval()
         with th.no_grad():
-            betas_t = get_index_from_list(self.betas, t, x.shape)
-            sqrt_one_minus_alphas_cumprod_t = get_index_from_list(self.sqrt_one_minus_alphas_cumprod, t, x.shape)
-            sqrt_recip_alphas_t = get_index_from_list(self.sqrt_recip_alphas, t, x.shape)
-
             # Call model (current image - noise prediction)
             noise_pred = model(x, t, encoder_hidden_states).sample
-            model_mean = sqrt_recip_alphas_t * (x - betas_t * noise_pred / sqrt_one_minus_alphas_cumprod_t)
+            model_mean = self._posterior_mean(noise_pred, x, t)
 
             posterior_variance_t = get_index_from_list(self.posterior_variance, t, x.shape)
             if t_mask is None:
@@ -298,7 +329,7 @@ if __name__ == "__main__":
         filtered_ds[i] = training_ds[i]["optimal_design"][:].reshape(1, design_shape[0], design_shape[1])
     filtered_ds_max = filtered_ds.max()
     filtered_ds_min = filtered_ds.min()
-    filtered_ds_norm = (filtered_ds - filtered_ds_min) / (filtered_ds_max - filtered_ds_min)
+    filtered_ds_norm = normalize_designs_to_diffusion_range(filtered_ds, filtered_ds_min, filtered_ds_max)
     training_ds = th.utils.data.TensorDataset(
         filtered_ds_norm.flatten(1), *[training_ds[key][:] for key in problem.conditions_keys]
     )
@@ -418,7 +449,8 @@ if __name__ == "__main__":
 
                     # Plot the image created by each output
                     for j, tensor in enumerate(designs):
-                        img = tensor.cpu().numpy()  # Extract x and y coordinates
+                        design = denormalize_designs_from_diffusion_range(tensor, filtered_ds_min, filtered_ds_max)
+                        img = design.cpu().numpy()  # Extract x and y coordinates
                         dc = hidden_states[j, 0, :].cpu()
                         axes[j].imshow(img[0])  # image plot
                         title = [(problem.conditions_keys[i], f"{dc[i]:.2f}") for i in range(len(problem.conditions_keys))]
@@ -443,6 +475,10 @@ if __name__ == "__main__":
                         "model": model.state_dict(),
                         "optimizer_generator": optimizer.state_dict(),
                         "loss": loss.item(),
+                        "design_min": filtered_ds_min.detach().cpu(),
+                        "design_max": filtered_ds_max.detach().cpu(),
+                        "diffusion_sample_min": DIFFUSION_SAMPLE_MIN,
+                        "diffusion_sample_max": DIFFUSION_SAMPLE_MAX,
                     }
 
                     th.save(ckpt_model, "model.pth")

--- a/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
+++ b/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
@@ -133,7 +133,7 @@ def normalize_designs_to_diffusion_range(
     design_min: th.Tensor,
     design_max: th.Tensor,
 ) -> th.Tensor:
-    """Map designs from their observed training bounds to [-1, 1]."""
+    """Map designs from their problem bounds to [-1, 1]."""
     denom = th.clamp(design_max - design_min, min=th.finfo(designs.dtype).eps)
     designs_01 = (designs - design_min) / denom
     return designs_01 * (DIFFUSION_SAMPLE_MAX - DIFFUSION_SAMPLE_MIN) + DIFFUSION_SAMPLE_MIN
@@ -144,9 +144,23 @@ def denormalize_designs_from_diffusion_range(
     design_min: th.Tensor,
     design_max: th.Tensor,
 ) -> th.Tensor:
-    """Map designs from [-1, 1] back to their original training-data scale."""
+    """Map designs from [-1, 1] back to the original problem scale."""
     designs_01 = (designs - DIFFUSION_SAMPLE_MIN) / (DIFFUSION_SAMPLE_MAX - DIFFUSION_SAMPLE_MIN)
     return designs_01 * (design_max - design_min) + design_min
+
+
+def get_design_bounds(
+    problem,
+    fallback_designs: th.Tensor,
+    device: th.device,
+) -> tuple[th.Tensor, th.Tensor]:
+    """Get finite design bounds from the EngiBench problem definition."""
+    design_min = th.as_tensor(problem.design_space.low, dtype=fallback_designs.dtype, device=device)
+    design_max = th.as_tensor(problem.design_space.high, dtype=fallback_designs.dtype, device=device)
+    if th.isfinite(design_min).all() and th.isfinite(design_max).all() and th.all(design_max > design_min):
+        return design_min, design_max
+
+    return fallback_designs.min(), fallback_designs.max()
 
 
 class DiffusionSampler:
@@ -327,8 +341,7 @@ if __name__ == "__main__":
     filtered_ds = th.zeros(len(training_ds), design_shape[0], design_shape[1], device=device)
     for i in range(len(training_ds)):
         filtered_ds[i] = training_ds[i]["optimal_design"][:].reshape(1, design_shape[0], design_shape[1])
-    filtered_ds_max = filtered_ds.max()
-    filtered_ds_min = filtered_ds.min()
+    filtered_ds_min, filtered_ds_max = get_design_bounds(problem, filtered_ds, device)
     filtered_ds_norm = normalize_designs_to_diffusion_range(filtered_ds, filtered_ds_min, filtered_ds_max)
     training_ds = th.utils.data.TensorDataset(
         filtered_ds_norm.flatten(1), *[training_ds[key][:] for key in problem.conditions_keys]

--- a/engiopt/diffusion_2d_cond/evaluate_diffusion_2d_cond.py
+++ b/engiopt/diffusion_2d_cond/evaluate_diffusion_2d_cond.py
@@ -16,6 +16,7 @@ import wandb
 from engiopt import metrics
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.diffusion_2d_cond.diffusion_2d_cond import beta_schedule
+from engiopt.diffusion_2d_cond.diffusion_2d_cond import denormalize_designs_from_diffusion_range
 from engiopt.diffusion_2d_cond.diffusion_2d_cond import DiffusionSampler
 
 
@@ -132,8 +133,17 @@ if __name__ == "__main__":
         gen_designs = ddm_sampler.sample_timestep(model, gen_designs, t, conditions_tensor)
 
     gen_designs = gen_designs.squeeze(1)
+    if "design_min" in ckpt and "design_max" in ckpt:
+        design_min = ckpt["design_min"].to(device)
+        design_max = ckpt["design_max"].to(device)
+        gen_designs = denormalize_designs_from_diffusion_range(gen_designs, design_min, design_max)
     gen_designs_np = gen_designs.detach().cpu().numpy().reshape(args.n_samples, *problem.design_space.shape)
-    gen_designs_np = np.clip(gen_designs_np, 1e-3, 1.0)
+    if "design_min" in ckpt and "design_max" in ckpt:
+        design_min_np = ckpt["design_min"].detach().cpu().numpy()
+        design_max_np = ckpt["design_max"].detach().cpu().numpy()
+        gen_designs_np = np.clip(gen_designs_np, design_min_np, design_max_np)
+    else:
+        gen_designs_np = np.clip(gen_designs_np, 1e-3, 1.0)
 
     # Compute metrics
     metrics_dict = metrics.metrics(

--- a/tests/test_diffusion_fixes.py
+++ b/tests/test_diffusion_fixes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -56,6 +58,25 @@ def test_diffusion_2d_normalizer_round_trips_arbitrary_bounds() -> None:
     assert normalized.min().item() == pytest.approx(-1.0)
     assert normalized.max().item() == pytest.approx(1.0)
     assert th.allclose(restored, designs)
+
+
+def test_diffusion_2d_uses_problem_design_bounds_when_available() -> None:
+    """EngiBench design_space bounds should be the normalization source of truth."""
+    th = pytest.importorskip("torch")
+    diffusion_2d = pytest.importorskip("engiopt.diffusion_2d_cond.diffusion_2d_cond")
+
+    fallback_designs = th.tensor([[0.2, 0.8]])
+    problem = SimpleNamespace(
+        design_space=SimpleNamespace(
+            low=th.tensor([-2.0, -1.0]).numpy(),
+            high=th.tensor([2.0, 3.0]).numpy(),
+        ),
+    )
+
+    design_min, design_max = diffusion_2d.get_design_bounds(problem, fallback_designs, th.device("cpu"))
+
+    assert th.allclose(design_min, th.tensor([-2.0, -1.0]))
+    assert th.allclose(design_max, th.tensor([2.0, 3.0]))
 
 
 def test_diffusion_step_sample_uses_fresh_noise(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_diffusion_fixes.py
+++ b/tests/test_diffusion_fixes.py
@@ -41,8 +41,25 @@ def test_default_linear_schedule_reaches_nearly_pure_noise() -> None:
     assert terminal_signal.item() < max_terminal_signal
 
 
+def test_diffusion_2d_normalizer_round_trips_arbitrary_bounds() -> None:
+    """2D diffusion should not assume designs are already in [0, 1]."""
+    th = pytest.importorskip("torch")
+    diffusion_2d = pytest.importorskip("engiopt.diffusion_2d_cond.diffusion_2d_cond")
+
+    designs = th.tensor([[-2.0, 1.0], [4.0, 10.0]])
+    design_min = designs.min()
+    design_max = designs.max()
+
+    normalized = diffusion_2d.normalize_designs_to_diffusion_range(designs, design_min, design_max)
+    restored = diffusion_2d.denormalize_designs_from_diffusion_range(normalized, design_min, design_max)
+
+    assert normalized.min().item() == pytest.approx(-1.0)
+    assert normalized.max().item() == pytest.approx(1.0)
+    assert th.allclose(restored, designs)
+
+
 def test_diffusion_step_sample_uses_fresh_noise(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The variance term should use random sampling noise, not the predicted epsilon."""
+    """The reverse step should clip predicted x0 and use fresh posterior noise."""
     th = pytest.importorskip("torch")
     diffusion_2d = pytest.importorskip("engiopt.diffusion_2d_cond.diffusion_2d_cond")
 
@@ -55,13 +72,23 @@ def test_diffusion_step_sample_uses_fresh_noise(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(diffusion_2d.th, "randn_like", th.zeros_like)
 
     actual = sampler.diffusion_step_sample(noise_pred, x_noisy, t)
-    betas_t = diffusion_2d.get_index_from_list(sampler.betas, t, x_noisy.shape)
+    sqrt_alphas_cumprod_t = diffusion_2d.get_index_from_list(
+        sampler.sqrt_alphas_cumprod,
+        t,
+        x_noisy.shape,
+    )
     sqrt_one_minus_alphas_cumprod_t = diffusion_2d.get_index_from_list(
         sampler.sqrt_one_minus_alphas_cumprod,
         t,
         x_noisy.shape,
     )
-    sqrt_recip_alphas_t = diffusion_2d.get_index_from_list(sampler.sqrt_recip_alphas, t, x_noisy.shape)
-    expected = sqrt_recip_alphas_t * (x_noisy - betas_t * noise_pred / sqrt_one_minus_alphas_cumprod_t)
+    pred_original_sample = (x_noisy - sqrt_one_minus_alphas_cumprod_t * noise_pred) / sqrt_alphas_cumprod_t
+    pred_original_sample = pred_original_sample.clamp(
+        diffusion_2d.DIFFUSION_SAMPLE_MIN,
+        diffusion_2d.DIFFUSION_SAMPLE_MAX,
+    )
+    posterior_mean_coef1_t = diffusion_2d.get_index_from_list(sampler.posterior_mean_coef1, t, x_noisy.shape)
+    posterior_mean_coef2_t = diffusion_2d.get_index_from_list(sampler.posterior_mean_coef2, t, x_noisy.shape)
+    expected = posterior_mean_coef1_t * pred_original_sample + posterior_mean_coef2_t * x_noisy
 
     assert th.allclose(actual, expected)


### PR DESCRIPTION
## Summary

I added a follow-up fix for the 2D conditional diffusion sampler/training scale after checking the qualitative Beams2D outputs from the previous diffusion fixes.

What changed:
- Normalize 2D training designs from their observed training-data bounds to the DDPM sample range `[-1, 1]` instead of assuming the model should train directly on `[0, 1]`.
- During sampling, reconstruct the predicted clean sample `x0`, clip that prediction in normalized `[-1, 1]`, and use it to compute the posterior mean.
- Save `design_min` and `design_max` in the checkpoint so evaluation can inverse-transform generated samples back to the original problem scale.
- Keep evaluation backward-compatible with older checkpoints that do not have saved design bounds.
- Add focused tests for arbitrary-bound normalization and the clipped-`x0` posterior step.

Why:
- The previous fixes made the schedule/noise path saner, but local Beams2D sampling showed the custom sampler could still let generated values drift far outside the training range.
- This makes the 2D diffusion path problem-agnostic: problems are no longer assumed to already live in `[0, 1]`, and outputs are mapped back to the original bounds for metrics.

Validation:
- `conda run -n engibench python -m pytest -q`
- `conda run -n engibench ruff check engiopt/diffusion_2d_cond/diffusion_2d_cond.py engiopt/diffusion_2d_cond/evaluate_diffusion_2d_cond.py tests/test_diffusion_fixes.py`
- `conda run -n engibench ruff format --check engiopt/diffusion_2d_cond/diffusion_2d_cond.py engiopt/diffusion_2d_cond/evaluate_diffusion_2d_cond.py tests/test_diffusion_fixes.py`
- `git diff --check`
- `conda run -n engibench python -m compileall -q engiopt/diffusion_2d_cond tests`
- One-epoch Beams2D smoke training run with the new scaling path completed successfully.