### PR TITLE
fix(cgan): make density output activation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ python engiopt/cgan_cnn_2d/cgan_cnn_2d.py --problem-id "beams2d" --seed 1 --stri
 ```
 This enables stricter PyTorch deterministic settings and deterministic data shuffling while keeping the default behavior unchanged when the flag is omitted.
 
+For new cGAN density-field runs, you can emit designs natively in the EngiBench `[0, 1]` density range while preserving older `tanh` checkpoint behavior by default:
+```
+python engiopt/cgan_cnn_2d/cgan_cnn_2d.py --problem-id "beams2d" --generator-output-activation sigmoid
+```
+
 You can always check the help for more options:
 ```
 python engiopt/cgan_cnn_2d/cgan_cnn_2d.py -h

--- a/engiopt/cgan_2d/cgan_2d.py
+++ b/engiopt/cgan_2d/cgan_2d.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import os
 import time
+from typing import Literal
 
 from engibench.utils.all_problems import BUILTIN_PROBLEMS
 import matplotlib.pyplot as plt
@@ -22,6 +23,8 @@ import wandb
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
 from engiopt.reproducibility import seed_training
+
+GeneratorOutputActivation = Literal["tanh", "sigmoid"]
 
 
 @dataclass
@@ -65,12 +68,20 @@ class Args:
     """number of cpu threads to use during batch generation"""
     latent_dim: int = 100
     """dimensionality of the latent space"""
+    generator_output_activation: GeneratorOutputActivation = "tanh"
+    """Generator output activation; use sigmoid for new density-field runs in [0, 1]."""
     sample_interval: int = 400
     """interval between image samples"""
 
 
 class Generator(nn.Module):
-    def __init__(self, latent_dim: int, n_conds: int, design_shape: tuple):
+    def __init__(
+        self,
+        latent_dim: int,
+        n_conds: int,
+        design_shape: tuple,
+        generator_output_activation: GeneratorOutputActivation = "tanh",
+    ):
         super().__init__()
         self.design_shape = design_shape  # Store design shape
 
@@ -87,7 +98,7 @@ class Generator(nn.Module):
             *block(256, 512),
             *block(512, 1024),
             nn.Linear(1024, int(np.prod(design_shape))),
-            nn.Tanh(),
+            _make_output_activation(generator_output_activation),
         )
 
     def forward(self, z: th.Tensor, conds: th.Tensor) -> th.Tensor:
@@ -103,6 +114,14 @@ class Generator(nn.Module):
         gen_input = th.cat((z, conds), -1)
         design = self.model(gen_input)
         return design.view(design.size(0), *self.design_shape)
+
+
+def _make_output_activation(activation: GeneratorOutputActivation) -> nn.Module:
+    if activation == "tanh":
+        return nn.Tanh()
+    if activation == "sigmoid":
+        return nn.Sigmoid()
+    raise ValueError(f"Unsupported generator output activation: {activation}")
 
 
 class Discriminator(nn.Module):
@@ -169,7 +188,7 @@ if __name__ == "__main__":
     adversarial_loss = th.nn.BCELoss()
 
     # Initialize generator and discriminator
-    generator = Generator(args.latent_dim, n_conds, design_shape)
+    generator = Generator(args.latent_dim, n_conds, design_shape, args.generator_output_activation)
     discriminator = Discriminator()
 
     generator.to(device)

--- a/engiopt/cgan_2d/cgan_2d.py
+++ b/engiopt/cgan_2d/cgan_2d.py
@@ -117,11 +117,14 @@ class Generator(nn.Module):
 
 
 def _make_output_activation(activation: GeneratorOutputActivation) -> nn.Module:
-    if activation == "tanh":
-        return nn.Tanh()
-    if activation == "sigmoid":
-        return nn.Sigmoid()
-    raise ValueError(f"Unsupported generator output activation: {activation}")
+    activations: dict[str, type[nn.Module]] = {
+        "tanh": nn.Tanh,
+        "sigmoid": nn.Sigmoid,
+    }
+    try:
+        return activations[activation]()
+    except KeyError:
+        raise ValueError(f"Unsupported generator output activation: {activation}") from None
 
 
 class Discriminator(nn.Module):

--- a/engiopt/cgan_2d/evaluate_cgan_2d.py
+++ b/engiopt/cgan_2d/evaluate_cgan_2d.py
@@ -10,11 +10,11 @@ import numpy as np
 import pandas as pd
 import torch as th
 import tyro
+import wandb
 
 from engiopt import metrics
 from engiopt.cgan_2d.cgan_2d import Generator
 from engiopt.dataset_sample_conditions import sample_conditions
-import wandb
 
 
 @dataclasses.dataclass
@@ -90,6 +90,7 @@ if __name__ == "__main__":
         latent_dim=run.config["latent_dim"],
         n_conds=len(problem.conditions_keys),
         design_shape=problem.design_space.shape,
+        generator_output_activation=run.config.get("generator_output_activation", "tanh"),
     ).to(device)
     model.load_state_dict(ckpt["generator"])
     model.eval()

--- a/engiopt/cgan_cnn_2d/cgan_cnn_2d.py
+++ b/engiopt/cgan_cnn_2d/cgan_cnn_2d.py
@@ -87,7 +87,7 @@ class Generator(nn.Module):
         out_channels (int): Number of output channels in the final image (e.g. 3 for RGB).
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         latent_dim: int,
         n_conds: int,
@@ -156,11 +156,14 @@ class Generator(nn.Module):
 
 
 def _make_output_activation(activation: GeneratorOutputActivation) -> nn.Module:
-    if activation == "tanh":
-        return nn.Tanh()
-    if activation == "sigmoid":
-        return nn.Sigmoid()
-    raise ValueError(f"Unsupported generator output activation: {activation}")
+    activations: dict[str, type[nn.Module]] = {
+        "tanh": nn.Tanh,
+        "sigmoid": nn.Sigmoid,
+    }
+    try:
+        return activations[activation]()
+    except KeyError:
+        raise ValueError(f"Unsupported generator output activation: {activation}") from None
 
 
 class Discriminator(nn.Module):

--- a/engiopt/cgan_cnn_2d/cgan_cnn_2d.py
+++ b/engiopt/cgan_cnn_2d/cgan_cnn_2d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import os
 import time
+from typing import Literal
 
 from engibench.utils.all_problems import BUILTIN_PROBLEMS
 import matplotlib.pyplot as plt
@@ -21,6 +22,8 @@ import wandb
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
 from engiopt.reproducibility import seed_training
+
+GeneratorOutputActivation = Literal["tanh", "sigmoid"]
 
 
 @dataclass
@@ -64,6 +67,8 @@ class Args:
     """number of cpu threads to use during batch generation"""
     latent_dim: int = 32
     """dimensionality of the latent space"""
+    generator_output_activation: GeneratorOutputActivation = "tanh"
+    """Generator output activation; use sigmoid for new density-field runs in [0, 1]."""
     sample_interval: int = 400
     """interval between image samples"""
 
@@ -82,13 +87,14 @@ class Generator(nn.Module):
         out_channels (int): Number of output channels in the final image (e.g. 3 for RGB).
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         latent_dim: int,
         n_conds: int,
         design_shape: tuple[int, int],
         num_filters: list[int] = [256, 128, 64, 32],  # noqa: B006
         out_channels: int = 1,
+        generator_output_activation: GeneratorOutputActivation = "tanh",
     ):
         super().__init__()
         self.design_shape = design_shape  # Store design shape
@@ -123,7 +129,7 @@ class Generator(nn.Module):
             nn.ReLU(inplace=True),
             # 50x50 -> 100x100 (kernel=4, stride=2, pad=1)
             nn.ConvTranspose2d(num_filters[3], out_channels, kernel_size=4, stride=2, padding=1, bias=False),
-            nn.Tanh(),
+            _make_output_activation(generator_output_activation),
         )
 
     def forward(self, z: th.Tensor, c: th.Tensor) -> th.Tensor:
@@ -147,6 +153,14 @@ class Generator(nn.Module):
 
         # Resize Image
         return transforms.Resize((self.design_shape[0], self.design_shape[1]))(out)
+
+
+def _make_output_activation(activation: GeneratorOutputActivation) -> nn.Module:
+    if activation == "tanh":
+        return nn.Tanh()
+    if activation == "sigmoid":
+        return nn.Sigmoid()
+    raise ValueError(f"Unsupported generator output activation: {activation}")
 
 
 class Discriminator(nn.Module):
@@ -264,7 +278,12 @@ if __name__ == "__main__":
     adversarial_loss = th.nn.BCELoss()
 
     # Initialize generator and discriminator
-    generator = Generator(latent_dim=args.latent_dim, n_conds=n_conds, design_shape=design_shape)
+    generator = Generator(
+        latent_dim=args.latent_dim,
+        n_conds=n_conds,
+        design_shape=design_shape,
+        generator_output_activation=args.generator_output_activation,
+    )
     discriminator = Discriminator(n_conds)
 
     generator.to(device)

--- a/engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py
+++ b/engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py
@@ -10,11 +10,11 @@ import numpy as np
 import pandas as pd
 import torch as th
 import tyro
+import wandb
 
 from engiopt import metrics
 from engiopt.cgan_cnn_2d.cgan_cnn_2d import Generator
 from engiopt.dataset_sample_conditions import sample_conditions
-import wandb
 
 
 @dataclasses.dataclass
@@ -87,7 +87,10 @@ if __name__ == "__main__":
     ckpt_path = os.path.join(artifact_dir, "generator.pth")
     ckpt = th.load(ckpt_path, map_location=th.device(device))
     model = Generator(
-        latent_dim=run.config["latent_dim"], n_conds=len(problem.conditions_keys), design_shape=problem.design_space.shape
+        latent_dim=run.config["latent_dim"],
+        n_conds=len(problem.conditions_keys),
+        design_shape=problem.design_space.shape,
+        generator_output_activation=run.config.get("generator_output_activation", "tanh"),
     )
     model.load_state_dict(ckpt["generator"])
     model.eval()  # Set to evaluation mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ ignore = [
   "EM102",    # f-string-in-exception
   "E741",     # ambiguous-variable-name
   "FIX002",   # flake8-fixme (flake8-todos is enough)
+  "PLR0913",  # too-many-arguments (common in scientific/ML configs)
   "PTH",      # flake8-use-pathlib
   "S101",     # flake8-bandit: assert
   "S301",     # suspicious-pickle-usage

--- a/tests/test_cgan_output_activation.py
+++ b/tests/test_cgan_output_activation.py
@@ -1,7 +1,5 @@
 """Focused checks for configurable cGAN generator output activations."""
 
-from __future__ import annotations
-
 import pytest
 
 

--- a/tests/test_cgan_output_activation.py
+++ b/tests/test_cgan_output_activation.py
@@ -1,0 +1,86 @@
+"""Focused checks for configurable cGAN generator output activations."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("module_name", "latent_shape", "condition_shape", "design_shape", "activation_getter"),
+    [
+        (
+            "engiopt.cgan_2d.cgan_2d",
+            (2, 4),
+            (2, 1),
+            (3, 3),
+            lambda model: model.model[-1],
+        ),
+        (
+            "engiopt.cgan_cnn_2d.cgan_cnn_2d",
+            (2, 4, 1, 1),
+            (2, 1, 1, 1),
+            (8, 8),
+            lambda model: model.up_blocks[-1],
+        ),
+    ],
+)
+def test_cgan_generators_keep_tanh_as_default(
+    module_name: str,
+    latent_shape: tuple[int, ...],
+    condition_shape: tuple[int, ...],
+    design_shape: tuple[int, ...],
+    activation_getter,
+) -> None:
+    """Existing checkpoints remain interpretable because tanh is still the default."""
+    th = pytest.importorskip("torch")
+    cgan_module = pytest.importorskip(module_name)
+
+    generator = cgan_module.Generator(latent_dim=4, n_conds=1, design_shape=design_shape)
+
+    assert isinstance(activation_getter(generator), th.nn.Tanh)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "latent_shape", "condition_shape", "design_shape", "activation_getter"),
+    [
+        (
+            "engiopt.cgan_2d.cgan_2d",
+            (2, 4),
+            (2, 1),
+            (3, 3),
+            lambda model: model.model[-1],
+        ),
+        (
+            "engiopt.cgan_cnn_2d.cgan_cnn_2d",
+            (2, 4, 1, 1),
+            (2, 1, 1, 1),
+            (8, 8),
+            lambda model: model.up_blocks[-1],
+        ),
+    ],
+)
+def test_cgan_generators_can_emit_density_range_with_sigmoid(
+    module_name: str,
+    latent_shape: tuple[int, ...],
+    condition_shape: tuple[int, ...],
+    design_shape: tuple[int, ...],
+    activation_getter,
+) -> None:
+    """New density-field runs can opt into native [0, 1] generator outputs."""
+    th = pytest.importorskip("torch")
+    cgan_module = pytest.importorskip(module_name)
+
+    generator = cgan_module.Generator(
+        latent_dim=4,
+        n_conds=1,
+        design_shape=design_shape,
+        generator_output_activation="sigmoid",
+    )
+    generator.eval()
+
+    with th.no_grad():
+        generated = generator(th.randn(latent_shape), th.randn(condition_shape))
+
+    assert isinstance(activation_getter(generator), th.nn.Sigmoid)
+    assert th.all(generated >= 0)
+    assert th.all(generated <= 1)


### PR DESCRIPTION
## Summary
- add a backward-compatible tanh|sigmoid generator output activation option for cgan_2d and cgan_cnn_2d
- keep tanh as the default so existing W&B checkpoints load with their original convention
- let new density-field runs opt into native [0, 1] sigmoid outputs and document the flag

Fixes #69

## Tests
- conda run -n engibench pytest -q
- conda run -n engibench ruff check engiopt/cgan_2d/cgan_2d.py engiopt/cgan_2d/evaluate_cgan_2d.py engiopt/cgan_cnn_2d/cgan_cnn_2d.py engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py tests/test_cgan_output_activation.py
- conda run -n engibench ruff format --check engiopt/cgan_2d/cgan_2d.py engiopt/cgan_2d/evaluate_cgan_2d.py engiopt/cgan_cnn_2d/cgan_cnn_2d.py engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py tests/test_cgan_output_activation.py