### PR TITLE
refactor(checkpoints): HF-only writes; configurable W&B read alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,14 @@ python engiopt/cgan_cnn_2d/cgan_cnn_2d.py --problem-id "beams2d" --track --wandb
 
 This will run a CGAN 2D using CNN model on the beams2d problem. `--track` will track the run on wandb, `--wandb-entity None` will use the default wandb entity, `--save-model` will save the model, `--n-epochs 200` will run for 200 epochs, and `--seed 1` will set the random seed.
 
-By default, `--save-model` now stores a self-contained checkpoint package on the Hugging Face Hub. The default backend is:
+By default, `--save-model` stores a self-contained checkpoint package on the Hugging Face Hub. The supported backends are:
 ```
---checkpoint-backend hf
+--checkpoint-backend hf    # default: upload to HF
+--checkpoint-backend none  # skip remote upload (local-only, for testing)
 ```
-You can still force legacy or hybrid behavior when needed:
-```
---checkpoint-backend wandb
---checkpoint-backend both
---checkpoint-backend none
-```
+W&B is no longer a checkpoint storage backend. W&B continues to be used for media, scalars, and run tracking; the W&B run summary records the HF repo, the seed-based convenience path, the exact uploaded HF revision, and an immutable run-specific HF package path for traceability.
 
 All HF-backed checkpoint packages contain the model files together with `run_config.json` and `metadata.json`, so evaluation does not depend on live WandB run config state.
-When W&B tracking is active, the HF package metadata also records the originating W&B run identity, and the W&B run summary records the HF repo, the seed-based convenience path, the exact uploaded HF revision, and an immutable run-specific HF package path.
 
 For reproducible debugging runs, you can additionally enable strict deterministic mode:
 ```
@@ -122,14 +117,14 @@ Evaluation now defaults to:
 ```
 In `auto` mode, EngiOpt tries to resolve checkpoints in this order:
 1. Hugging Face package for the model family, problem, and seed
-2. Legacy WandB model artifact
+2. Legacy WandB model artifact (kept as a safety net for runs trained before the HF cutover; will be removed once all in-use artifacts are migrated)
 3. Explicit local checkpoint package directory if you pass `--local-model-dir`
 
 For new HF-backed runs, EngiOpt maintains both:
 - a seed-based convenience path such as `beams2d/seed_1`
 - an immutable run-specific path such as `beams2d/seed_1/run_<wandb_run_id>`
 
-You can force legacy WandB loading for historical runs:
+You can force legacy WandB loading for historical runs (while the fallback is still present):
 ```
 python engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py --problem-id "beams2d" --seed 1 --model-source wandb
 ```

--- a/README.md
+++ b/README.md
@@ -80,59 +80,27 @@ To train a model, you can run (for example):
 python engiopt/cgan_cnn_2d/cgan_cnn_2d.py --problem-id "beams2d" --track --wandb-entity None --save-model --n-epochs 200 --seed 1
 ```
 
-This will run a CGAN 2D using CNN model on the beams2d problem. `--track` will track the run on wandb, `--wandb-entity None` will use the default wandb entity, `--save-model` will save the model, `--n-epochs 200` will run for 200 epochs, and `--seed 1` will set the random seed.
+This trains a CGAN 2D w/ CNN on `beams2d`. The flags mirror W&B's: `--track` enables W&B logging, `--wandb-entity`/`--wandb-project` say where the run goes, `--save-model` uploads the checkpoint to HuggingFace, and `--hf-entity`/`--hf-repo-prefix` say where the checkpoint goes.
 
-By default, `--save-model` stores a self-contained checkpoint package on the Hugging Face Hub. The supported backends are:
-```
---checkpoint-backend hf    # default: upload to HF
---checkpoint-backend none  # skip remote upload (local-only, for testing)
-```
-W&B is no longer a checkpoint storage backend. W&B continues to be used for media, scalars, and run tracking; the W&B run summary records the HF repo, the seed-based convenience path, the exact uploaded HF revision, and an immutable run-specific HF package path for traceability.
+W&B holds media, scalars, and run history. HuggingFace holds the model weights. One log-in per service:
 
-All HF-backed checkpoint packages contain the model files together with `run_config.json` and `metadata.json`, so evaluation does not depend on live WandB run config state.
+```
+wandb login              # for tracking
+huggingface-cli login    # for checkpoints (or: export HF_TOKEN=...)
+```
+
+The defaults (`--hf-entity IDEALLab --hf-repo-prefix engiopt`) push to `huggingface.co/IDEALLab/engiopt-cgan-cnn-2d/beams2d/seed_1/`. The W&B run summary records the HF path for traceability. Each checkpoint package contains the model files plus `run_config.json` and `metadata.json`, so evaluation needs no live W&B state.
 
 For reproducible debugging runs, you can additionally enable strict deterministic mode:
 ```
 python engiopt/cgan_cnn_2d/cgan_cnn_2d.py --problem-id "beams2d" --seed 1 --strict-determinism
 ```
-This enables stricter PyTorch deterministic settings and deterministic data shuffling while keeping the default behavior unchanged when the flag is omitted.
 
-You can always check the help for more options:
+Then evaluate:
 ```
-python engiopt/cgan_cnn_2d/cgan_cnn_2d.py -h
+python engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py --problem-id "beams2d" --seed 1 --n-samples 10
 ```
-
-There are other available models in the `engiopt/` folder.
-
-Then you can restore a trained model and evaluate it:
-
-```
-python engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py --problem-id "beams2d" --wandb-entity None --seed 1 --n-samples 10
-```
-This will generate 10 designs from the trained model and run some [metrics](https://github.com/IDEALLab/EngiOpt/blob/main/engiopt/metrics.py) on them. This is what we used to generate the results in the paper.
-
-Evaluation now defaults to:
-```
---model-source auto
-```
-In `auto` mode, EngiOpt tries to resolve checkpoints in this order:
-1. Hugging Face package for the model family, problem, and seed
-2. Legacy WandB model artifact (kept as a safety net for runs trained before the HF cutover; will be removed once all in-use artifacts are migrated)
-3. Explicit local checkpoint package directory if you pass `--local-model-dir`
-
-For new HF-backed runs, EngiOpt maintains both:
-- a seed-based convenience path such as `beams2d/seed_1`
-- an immutable run-specific path such as `beams2d/seed_1/run_<wandb_run_id>`
-
-You can force legacy WandB loading for historical runs (while the fallback is still present):
-```
-python engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py --problem-id "beams2d" --seed 1 --model-source wandb
-```
-
-You can also point evaluation at a local package directory:
-```
-python engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py --problem-id "beams2d" --seed 1 --model-source local --local-model-dir /path/to/package
-```
+Evaluation pulls the checkpoint from HF automatically. For runs trained before the HF cutover, evaluation transparently falls back to the legacy W&B artifact. Pass `--hf-entity` / `--hf-repo-prefix` to point at a different HF repo.
 
 ### Surrogate model
 

--- a/engiopt/cgan_1d/cgan_1d.py
+++ b/engiopt/cgan_1d/cgan_1d.py
@@ -419,10 +419,6 @@ if __name__ == "__main__":
                         checkpoint_files={"generator.pth": "generator.pth", "discriminator.pth": "discriminator.pth"},
                         run_config=vars(args),
                         primary_files=["generator.pth"],
-                        wandb_artifacts={
-                            f"{args.problem_id}_{args.algo}_generator": "generator.pth",
-                            f"{args.problem_id}_{args.algo}_discriminator": "discriminator.pth",
-                        },
                     )
 
     wandb.finish()

--- a/engiopt/cgan_1d/cgan_1d.py
+++ b/engiopt/cgan_1d/cgan_1d.py
@@ -22,7 +22,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -66,14 +65,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -409,10 +404,10 @@ if __name__ == "__main__":
                     th.save(ckpt_gen, "generator.pth")
                     th.save(ckpt_disc, "discriminator.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,

--- a/engiopt/cgan_1d/evaluate_cgan_1d.py
+++ b/engiopt/cgan_1d/evaluate_cgan_1d.py
@@ -15,7 +15,6 @@ import tyro
 from engiopt import metrics
 from engiopt.cgan_1d.cgan_1d import Generator
 from engiopt.cgan_1d.cgan_1d import prepare_data
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 
@@ -32,14 +31,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 10
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -84,7 +79,7 @@ if __name__ == "__main__":
 
     ### Set Up Generator ###
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="cgan_1d",
         seed=seed,
@@ -94,7 +89,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"generator.pth": f"{args.problem_id}_cgan_1d_generator"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/cgan_2d/cgan_2d.py
+++ b/engiopt/cgan_2d/cgan_2d.py
@@ -19,7 +19,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -42,14 +41,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -328,10 +323,10 @@ if __name__ == "__main__":
                     th.save(ckpt_gen, "generator.pth")
                     th.save(ckpt_disc, "discriminator.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,

--- a/engiopt/cgan_2d/cgan_2d.py
+++ b/engiopt/cgan_2d/cgan_2d.py
@@ -338,10 +338,6 @@ if __name__ == "__main__":
                         checkpoint_files={"generator.pth": "generator.pth", "discriminator.pth": "discriminator.pth"},
                         run_config=vars(args),
                         primary_files=["generator.pth"],
-                        wandb_artifacts={
-                            f"{args.problem_id}_{args.algo}_generator": "generator.pth",
-                            f"{args.problem_id}_{args.algo}_discriminator": "discriminator.pth",
-                        },
                     )
 
     wandb.finish()

--- a/engiopt/cgan_2d/evaluate_cgan_2d.py
+++ b/engiopt/cgan_2d/evaluate_cgan_2d.py
@@ -13,7 +13,6 @@ import tyro
 
 from engiopt import metrics
 from engiopt.cgan_2d.cgan_2d import Generator
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 
@@ -30,14 +29,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name (if any)."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -76,7 +71,7 @@ if __name__ == "__main__":
 
     ### Set Up Generator ###
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="cgan_2d",
         seed=seed,
@@ -86,7 +81,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"generator.pth": f"{args.problem_id}_cgan_2d_generator"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/cgan_bezier/cgan_bezier.py
+++ b/engiopt/cgan_bezier/cgan_bezier.py
@@ -664,10 +664,6 @@ if __name__ == "__main__":
                     },
                     run_config=vars(args),
                     primary_files=["bezier_generator.pth"],
-                    wandb_artifacts={
-                        f"{args.problem_id}_{args.algo}_generator": "bezier_generator.pth",
-                        f"{args.problem_id}_{args.algo}_discriminator": "bezier_discriminator.pth",
-                    },
                 )
 
     if args.track:

--- a/engiopt/cgan_bezier/cgan_bezier.py
+++ b/engiopt/cgan_bezier/cgan_bezier.py
@@ -19,7 +19,6 @@ from torch import nn
 import torch.nn.functional as f
 import tyro
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -48,14 +47,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 6
     """Random seed."""
 
@@ -651,10 +646,10 @@ if __name__ == "__main__":
                 th.save(ckpt_gen, "bezier_generator.pth")
                 th.save(ckpt_disc, "bezier_discriminator.pth")
                 save_checkpoint_package(
-                    checkpoint_backend=args.checkpoint_backend,
+                    checkpoint_backend="hf",
                     hf_entity=args.hf_entity,
                     hf_repo_prefix=args.hf_repo_prefix,
-                    hf_private=args.hf_private,
+                    hf_private=False,
                     problem_id=args.problem_id,
                     algo=args.algo,
                     seed=args.seed,

--- a/engiopt/cgan_cnn_2d/cgan_cnn_2d.py
+++ b/engiopt/cgan_cnn_2d/cgan_cnn_2d.py
@@ -437,10 +437,6 @@ if __name__ == "__main__":
                         },
                         run_config=vars(args),
                         primary_files=["generator.pth"],
-                        wandb_artifacts={
-                            f"{args.problem_id}_{args.algo}_generator": "generator.pth",
-                            f"{args.problem_id}_{args.algo}_discriminator": "discriminator.pth",
-                        },
                     )
 
     wandb.finish()

--- a/engiopt/cgan_cnn_2d/cgan_cnn_2d.py
+++ b/engiopt/cgan_cnn_2d/cgan_cnn_2d.py
@@ -18,7 +18,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -41,14 +40,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -424,10 +419,10 @@ if __name__ == "__main__":
                     th.save(ckpt_gen, "generator.pth")
                     th.save(ckpt_disc, "discriminator.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,

--- a/engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py
+++ b/engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py
@@ -13,7 +13,6 @@ import tyro
 
 from engiopt import metrics
 from engiopt.cgan_cnn_2d.cgan_cnn_2d import Generator
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 
@@ -30,14 +29,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -76,7 +71,7 @@ if __name__ == "__main__":
     ### Set Up Generator ###
 
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="cgan_cnn_2d",
         seed=seed,
@@ -86,7 +81,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"generator.pth": f"{args.problem_id}_cgan_cnn_2d_generator"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/cgan_cnn_3d/cgan_cnn_3d.py
+++ b/engiopt/cgan_cnn_3d/cgan_cnn_3d.py
@@ -22,7 +22,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.metrics import dpp_diversity
 from engiopt.metrics import mmd
@@ -49,14 +48,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -692,10 +687,10 @@ if __name__ == "__main__":
             th.save(ckpt_gen, "generator_3d.pth")
             th.save(ckpt_disc, "discriminator_3d.pth")
             save_checkpoint_package(
-                checkpoint_backend=args.checkpoint_backend,
+                checkpoint_backend="hf",
                 hf_entity=args.hf_entity,
                 hf_repo_prefix=args.hf_repo_prefix,
-                hf_private=args.hf_private,
+                hf_private=False,
                 problem_id=args.problem_id,
                 algo=args.algo,
                 seed=args.seed,

--- a/engiopt/cgan_cnn_3d/cgan_cnn_3d.py
+++ b/engiopt/cgan_cnn_3d/cgan_cnn_3d.py
@@ -702,10 +702,6 @@ if __name__ == "__main__":
                 checkpoint_files={"generator_3d.pth": "generator_3d.pth", "discriminator_3d.pth": "discriminator_3d.pth"},
                 run_config=vars(args),
                 primary_files=["generator_3d.pth"],
-                wandb_artifacts={
-                    f"{args.problem_id}_{args.algo}_generator_3d": "generator_3d.pth",
-                    f"{args.problem_id}_{args.algo}_discriminator_3d": "discriminator_3d.pth",
-                },
             )
 
             print("3D models saved successfully!")

--- a/engiopt/cgan_cnn_3d/evaluate_cgan_cnn_3d.py
+++ b/engiopt/cgan_cnn_3d/evaluate_cgan_cnn_3d.py
@@ -13,7 +13,6 @@ import tyro
 
 from engiopt import metrics
 from engiopt.cgan_cnn_3d.cgan_cnn_3d import Generator3D
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 
@@ -30,14 +29,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -77,7 +72,7 @@ if __name__ == "__main__":
     ### Set Up Generator ###
 
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="cgan_cnn_3d",
         seed=seed,
@@ -87,7 +82,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"generator_3d.pth": f"{args.problem_id}_cgan_cnn_3d_generator_3d"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/cgan_vae/cgan_vae.py
+++ b/engiopt/cgan_vae/cgan_vae.py
@@ -22,7 +22,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.metrics import dpp_diversity
 from engiopt.metrics import mmd
@@ -49,14 +48,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -819,10 +814,10 @@ if __name__ == "__main__":
             )
 
             save_checkpoint_package(
-                checkpoint_backend=args.checkpoint_backend,
+                checkpoint_backend="hf",
                 hf_entity=args.hf_entity,
                 hf_repo_prefix=args.hf_repo_prefix,
-                hf_private=args.hf_private,
+                hf_private=False,
                 problem_id=args.problem_id,
                 algo=args.algo,
                 seed=args.seed,

--- a/engiopt/cgan_vae/cgan_vae.py
+++ b/engiopt/cgan_vae/cgan_vae.py
@@ -829,7 +829,6 @@ if __name__ == "__main__":
                 checkpoint_files={"multiview_3d_vaegan.pth": "multiview_3d_vaegan.pth"},
                 run_config=vars(args),
                 primary_files=["multiview_3d_vaegan.pth"],
-                wandb_artifacts={f"{args.problem_id}_{args.algo}_models": "multiview_3d_vaegan.pth"},
             )
 
             print("3D vae models saved successfully!")

--- a/engiopt/cgan_vae/evaluate_cgan_vae.py
+++ b/engiopt/cgan_vae/evaluate_cgan_vae.py
@@ -13,7 +13,6 @@ import tyro
 
 from engiopt import metrics
 from engiopt.cgan_vae.cgan_vae import Generator3D
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 
@@ -30,14 +29,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -77,7 +72,7 @@ if __name__ == "__main__":
     ### Set Up Generator ###
 
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="cgan_vae",
         seed=seed,
@@ -87,7 +82,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"multiview_3d_vaegan.pth": f"{args.problem_id}_cgan_vae_models"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/checkpoint_store.py
+++ b/engiopt/checkpoint_store.py
@@ -15,7 +15,7 @@ from huggingface_hub import snapshot_download
 
 import wandb
 
-CheckpointBackend = Literal["hf", "wandb", "both", "none"]
+CheckpointBackend = Literal["hf", "none"]
 ModelSource = Literal["auto", "hf", "wandb", "local"]
 
 
@@ -66,9 +66,12 @@ def save_checkpoint_package(  # noqa: PLR0913
     metadata: dict[str, Any] | None = None,
     primary_files: list[str] | None = None,
     extra_path_parts: list[str] | None = None,
-    wandb_artifacts: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Save a checkpoint package to the configured remote backends."""
+    """Save a checkpoint package to HuggingFace.
+
+    W&B is no longer a checkpoint storage backend; the active W&B run still
+    receives a summary pointing at the HF package for traceability.
+    """
     info: dict[str, Any] = {
         "checkpoint_backend": checkpoint_backend,
         "hf_repo_id": None,
@@ -88,7 +91,7 @@ def save_checkpoint_package(  # noqa: PLR0913
     )
     metadata_payload.update(_build_wandb_run_metadata())
 
-    if checkpoint_backend in {"hf", "both"}:
+    if checkpoint_backend == "hf":
         repo_id = build_hf_repo_id(hf_entity, hf_repo_prefix, algo)
         package_path = build_hf_package_path(problem_id, seed, extra_path_parts)
         info["hf_repo_id"] = repo_id
@@ -124,12 +127,6 @@ def save_checkpoint_package(  # noqa: PLR0913
         info["hf_revision"] = revision
         metadata_payload["hf_revision"] = revision
 
-    if checkpoint_backend in {"wandb", "both"} and wandb_artifacts and wandb.run is not None:
-        for artifact_name, file_path in wandb_artifacts.items():
-            artifact = wandb.Artifact(artifact_name, type="model", metadata=metadata_payload)
-            artifact.add_file(file_path)
-            wandb.log_artifact(artifact, aliases=[f"seed_{seed}"])
-
     if wandb.run is not None:
         _log_checkpoint_summary_to_wandb(metadata_payload, info)
 
@@ -149,10 +146,18 @@ def resolve_named_checkpoint(  # noqa: PLR0913
     wandb_entity: str | None,
     wandb_artifact_names: dict[str, str],
     wandb_config_artifact_name: str | None = None,
+    wandb_artifact_alias: str | None = None,
     local_model_dir: str | None = None,
     extra_path_parts: list[str] | None = None,
 ) -> ResolvedCheckpoint:
-    """Resolve a checkpoint package by the standard EngiOpt problem/algo/seed naming."""
+    """Resolve a checkpoint package by the standard EngiOpt problem/algo/seed naming.
+
+    ``wandb_artifact_alias`` overrides the default ``f"seed_{seed}"`` alias used when
+    falling back to legacy W&B artifacts. Callers with custom alias schemes (e.g.
+    ``f"seed_{seed}_rec{r}_perf{p}"``) pass it here so the read-fallback resolves
+    historical artifacts that pre-date the HF cutover.
+    """
+    alias = wandb_artifact_alias or f"seed_{seed}"
     errors: list[str] = []
     if model_source in {"auto", "hf"}:
         try:
@@ -173,7 +178,7 @@ def resolve_named_checkpoint(  # noqa: PLR0913
                 artifact_names=wandb_artifact_names,
                 wandb_project=wandb_project,
                 wandb_entity=wandb_entity,
-                seed=seed,
+                alias=alias,
                 config_artifact_name=wandb_config_artifact_name,
             )
         except Exception as exc:
@@ -280,7 +285,7 @@ def _resolve_wandb_package(
     artifact_names: dict[str, str],
     wandb_project: str,
     wandb_entity: str | None,
-    seed: int,
+    alias: str,
     config_artifact_name: str | None,
 ) -> ResolvedCheckpoint:
     api = wandb.Api()
@@ -290,7 +295,7 @@ def _resolve_wandb_package(
             artifact_name=artifact_name,
             wandb_project=wandb_project,
             wandb_entity=wandb_entity,
-            seed=seed,
+            alias=alias,
         )
         artifact = api.artifact(artifact_path, type="model")
         artifact_dir = artifact.download()
@@ -301,7 +306,7 @@ def _resolve_wandb_package(
         artifact_name=config_artifact,
         wandb_project=wandb_project,
         wandb_entity=wandb_entity,
-        seed=seed,
+        alias=alias,
     )
     artifact = api.artifact(config_artifact_path, type="model")
     run = artifact.logged_by()
@@ -320,7 +325,7 @@ def _resolve_wandb_package(
                     artifact_name=artifact_name,
                     wandb_project=wandb_project,
                     wandb_entity=wandb_entity,
-                    seed=seed,
+                    alias=alias,
                 )
                 for file_name, artifact_name in artifact_names.items()
             },
@@ -417,10 +422,10 @@ def _build_wandb_artifact_path(
     artifact_name: str,
     wandb_project: str,
     wandb_entity: str | None,
-    seed: int,
+    alias: str,
 ) -> str:
     project_path = f"{wandb_entity}/{wandb_project}" if wandb_entity is not None else wandb_project
-    return f"{project_path}/{artifact_name}:seed_{seed}"
+    return f"{project_path}/{artifact_name}:{alias}"
 
 
 def _build_metadata(  # noqa: PLR0913

--- a/engiopt/diffusion_1d/diffusion_1d.py
+++ b/engiopt/diffusion_1d/diffusion_1d.py
@@ -22,7 +22,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -102,14 +101,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -285,10 +280,10 @@ if __name__ == "__main__":
 
                     th.save(ckpt, "model.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,

--- a/engiopt/diffusion_1d/diffusion_1d.py
+++ b/engiopt/diffusion_1d/diffusion_1d.py
@@ -295,7 +295,6 @@ if __name__ == "__main__":
                         checkpoint_files={"model.pth": "model.pth"},
                         run_config=vars(args),
                         primary_files=["model.pth"],
-                        wandb_artifacts={f"{args.problem_id}_{args.algo}_model": "model.pth"},
                     )
 
     wandb.finish()

--- a/engiopt/diffusion_1d/evaluate_diffusion_1d.py
+++ b/engiopt/diffusion_1d/evaluate_diffusion_1d.py
@@ -15,7 +15,6 @@ import torch as th
 import tyro
 
 from engiopt import metrics
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.diffusion_1d.diffusion_1d import prepare_data
@@ -33,14 +32,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 10
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -93,7 +88,7 @@ if __name__ == "__main__":
 
     ### Load Diffusion Model ###
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="diffusion_1d",
         seed=seed,
@@ -103,7 +98,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"model.pth": f"{args.problem_id}_diffusion_1d_model"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
+++ b/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
@@ -18,7 +18,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -44,14 +43,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -453,10 +448,10 @@ if __name__ == "__main__":
 
                     th.save(ckpt_model, "model.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,

--- a/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
+++ b/engiopt/diffusion_2d_cond/diffusion_2d_cond.py
@@ -463,7 +463,6 @@ if __name__ == "__main__":
                         checkpoint_files={"model.pth": "model.pth"},
                         run_config=vars(args),
                         primary_files=["model.pth"],
-                        wandb_artifacts={f"{args.problem_id}_{args.algo}_model": "model.pth"},
                     )
 
     wandb.finish()

--- a/engiopt/diffusion_2d_cond/evaluate_diffusion_2d_cond.py
+++ b/engiopt/diffusion_2d_cond/evaluate_diffusion_2d_cond.py
@@ -13,7 +13,6 @@ import torch as th
 import tyro
 
 from engiopt import metrics
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.diffusion_2d_cond.diffusion_2d_cond import beta_schedule
@@ -32,14 +31,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -80,7 +75,7 @@ if __name__ == "__main__":
 
     ### Set Up Diffusion Model ###
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="diffusion_2d_cond",
         seed=seed,
@@ -90,7 +85,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"model.pth": f"{args.problem_id}_diffusion_2d_cond_model"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/gan_1d/evaluate_gan_1d.py
+++ b/engiopt/gan_1d/evaluate_gan_1d.py
@@ -13,7 +13,6 @@ import torch as th
 import tyro
 
 from engiopt import metrics
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.gan_1d.gan_1d import Generator
@@ -32,14 +31,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -84,7 +79,7 @@ if __name__ == "__main__":
 
     ### Set Up Generator ###
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="gan_1d",
         seed=seed,
@@ -94,7 +89,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"generator.pth": f"{args.problem_id}_gan_1d_generator"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/gan_1d/gan_1d.py
+++ b/engiopt/gan_1d/gan_1d.py
@@ -21,7 +21,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -48,14 +47,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -350,10 +345,10 @@ if __name__ == "__main__":
                     th.save(ckpt_gen, "generator.pth")
                     th.save(ckpt_disc, "discriminator.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,

--- a/engiopt/gan_1d/gan_1d.py
+++ b/engiopt/gan_1d/gan_1d.py
@@ -360,10 +360,6 @@ if __name__ == "__main__":
                         checkpoint_files={"generator.pth": "generator.pth", "discriminator.pth": "discriminator.pth"},
                         run_config=vars(args),
                         primary_files=["generator.pth"],
-                        wandb_artifacts={
-                            f"{args.problem_id}_{args.algo}_generator": "generator.pth",
-                            f"{args.problem_id}_{args.algo}_discriminator": "discriminator.pth",
-                        },
                     )
 
     wandb.finish()

--- a/engiopt/gan_2d/evaluate_gan_2d.py
+++ b/engiopt/gan_2d/evaluate_gan_2d.py
@@ -12,7 +12,6 @@ import torch as th
 import tyro
 
 from engiopt import metrics
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.gan_2d.gan_2d import Generator
@@ -30,14 +29,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -76,7 +71,7 @@ if __name__ == "__main__":
 
     ### Set Up Generator ###
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="gan_2d",
         seed=seed,
@@ -86,7 +81,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"generator.pth": f"{args.problem_id}_gan_2d_generator"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/gan_2d/gan_2d.py
+++ b/engiopt/gan_2d/gan_2d.py
@@ -18,7 +18,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -41,14 +40,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -288,10 +283,10 @@ if __name__ == "__main__":
                     th.save(ckpt_gen, "generator.pth")
                     th.save(ckpt_disc, "discriminator.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,

--- a/engiopt/gan_2d/gan_2d.py
+++ b/engiopt/gan_2d/gan_2d.py
@@ -298,10 +298,6 @@ if __name__ == "__main__":
                         checkpoint_files={"generator.pth": "generator.pth", "discriminator.pth": "discriminator.pth"},
                         run_config=vars(args),
                         primary_files=["generator.pth"],
-                        wandb_artifacts={
-                            f"{args.problem_id}_{args.algo}_generator": "generator.pth",
-                            f"{args.problem_id}_{args.algo}_discriminator": "discriminator.pth",
-                        },
                     )
 
     wandb.finish()

--- a/engiopt/gan_bezier/evaluate_gan_bezier.py
+++ b/engiopt/gan_bezier/evaluate_gan_bezier.py
@@ -13,7 +13,6 @@ import torch as th
 import tyro
 
 from engiopt import metrics
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.gan_bezier.gan_bezier import Generator
@@ -38,14 +37,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -86,7 +81,7 @@ if __name__ == "__main__":
 
     ### Set Up Generator ###
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="gan_bezier",
         seed=seed,
@@ -96,7 +91,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"bezier_generator.pth": f"{args.problem_id}_gan_bezier_generator"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/gan_bezier/gan_bezier.py
+++ b/engiopt/gan_bezier/gan_bezier.py
@@ -19,7 +19,6 @@ from torch import nn
 import torch.nn.functional as f
 import tyro
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -48,14 +47,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -630,10 +625,10 @@ if __name__ == "__main__":
                 th.save(ckpt_gen, "bezier_generator.pth")
                 th.save(ckpt_disc, "bezier_discriminator.pth")
                 save_checkpoint_package(
-                    checkpoint_backend=args.checkpoint_backend,
+                    checkpoint_backend="hf",
                     hf_entity=args.hf_entity,
                     hf_repo_prefix=args.hf_repo_prefix,
-                    hf_private=args.hf_private,
+                    hf_private=False,
                     problem_id=args.problem_id,
                     algo=args.algo,
                     seed=args.seed,

--- a/engiopt/gan_bezier/gan_bezier.py
+++ b/engiopt/gan_bezier/gan_bezier.py
@@ -643,10 +643,6 @@ if __name__ == "__main__":
                     },
                     run_config=vars(args),
                     primary_files=["bezier_generator.pth"],
-                    wandb_artifacts={
-                        f"{args.problem_id}_{args.algo}_generator": "bezier_generator.pth",
-                        f"{args.problem_id}_{args.algo}_discriminator": "bezier_discriminator.pth",
-                    },
                 )
 
     if args.track:

--- a/engiopt/gan_cnn_2d/evaluate_gan_cnn_2d.py
+++ b/engiopt/gan_cnn_2d/evaluate_gan_cnn_2d.py
@@ -12,7 +12,6 @@ import torch as th
 import tyro
 
 from engiopt import metrics
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.gan_cnn_2d.gan_cnn_2d import Generator
@@ -30,14 +29,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name (if any)."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -76,7 +71,7 @@ if __name__ == "__main__":
     ### Set Up Generator ###
 
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="gan_cnn_2d",
         seed=seed,
@@ -86,7 +81,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"generator.pth": f"{args.problem_id}_gan_cnn_2d_generator"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/gan_cnn_2d/gan_cnn_2d.py
+++ b/engiopt/gan_cnn_2d/gan_cnn_2d.py
@@ -18,7 +18,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -41,14 +40,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -343,10 +338,10 @@ if __name__ == "__main__":
                     th.save(ckpt_gen, "generator.pth")
                     th.save(ckpt_disc, "discriminator.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,

--- a/engiopt/gan_cnn_2d/gan_cnn_2d.py
+++ b/engiopt/gan_cnn_2d/gan_cnn_2d.py
@@ -353,10 +353,6 @@ if __name__ == "__main__":
                         checkpoint_files={"generator.pth": "generator.pth", "discriminator.pth": "discriminator.pth"},
                         run_config=vars(args),
                         primary_files=["generator.pth"],
-                        wandb_artifacts={
-                            f"{args.problem_id}_{args.algo}_generator": "generator.pth",
-                            f"{args.problem_id}_{args.algo}_discriminator": "discriminator.pth",
-                        },
                     )
 
     wandb.finish()

--- a/engiopt/pixel_cnn_pp_2d/evaluate_pixel_cnn_pp_2d.py
+++ b/engiopt/pixel_cnn_pp_2d/evaluate_pixel_cnn_pp_2d.py
@@ -12,7 +12,6 @@ import torch as th
 import tyro
 
 from engiopt import metrics
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.pixel_cnn_pp_2d.pixel_cnn_pp_2d import PixelCNNpp
@@ -33,14 +32,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -83,7 +78,7 @@ if __name__ == "__main__":
 
     # Set up PixelCNN++ model
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="pixel_cnn_pp_2d",
         seed=seed,
@@ -93,7 +88,6 @@ if __name__ == "__main__":
         wandb_project=args.wandb_project,
         wandb_entity=args.wandb_entity,
         wandb_artifact_names={"model.pth": f"{args.problem_id}_pixel_cnn_pp_2d_model"},
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 

--- a/engiopt/pixel_cnn_pp_2d/pixel_cnn_pp_2d.py
+++ b/engiopt/pixel_cnn_pp_2d/pixel_cnn_pp_2d.py
@@ -912,7 +912,6 @@ if __name__ == "__main__":
                         checkpoint_files={"model.pth": "model.pth"},
                         run_config=vars(args),
                         primary_files=["model.pth"],
-                        wandb_artifacts={f"{args.problem_id}_{args.algo}_model": "model.pth"},
                     )
 
     wandb.finish()

--- a/engiopt/pixel_cnn_pp_2d/pixel_cnn_pp_2d.py
+++ b/engiopt/pixel_cnn_pp_2d/pixel_cnn_pp_2d.py
@@ -25,7 +25,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -48,14 +47,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved model weights."""
     hf_entity: str = "IDEALLab"
     """HF org/user where checkpoints are stored."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used for model-family repositories."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -902,10 +897,10 @@ if __name__ == "__main__":
 
                     th.save(ckpt_model, "model.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,

--- a/engiopt/surrogate_model/mlp_tabular_only.py
+++ b/engiopt/surrogate_model/mlp_tabular_only.py
@@ -369,7 +369,6 @@ def main(args: Args) -> float:  # noqa: PLR0915
             metadata={"target_col": args.target_col},
             primary_files=[os.path.basename(pipeline_filename)],
             extra_path_parts=[args.target_col],
-            wandb_artifacts={f"{run_name}_model": pipeline_filename},
         )
         if args.track:
             print("[INFO] Uploaded model artifact to configured checkpoint backend(s).")

--- a/engiopt/surrogate_model/mlp_tabular_only.py
+++ b/engiopt/surrogate_model/mlp_tabular_only.py
@@ -24,7 +24,6 @@ import wandb
 
 from engiopt.args_utils import parse_list_from_single_item_list
 from engiopt.args_utils import parse_list_from_string
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -96,10 +95,8 @@ class Args:
     track: bool = True
     wandb_project: str = "engiopt"
     wandb_entity: str | None = None
-    checkpoint_backend: CheckpointBackend = "hf"
     hf_entity: str = "IDEALLab"
     hf_repo_prefix: str = "engiopt"
-    hf_private: bool = False
     seed: int = 42
     strict_determinism: bool = False
     n_ensembles: int = 1
@@ -357,10 +354,10 @@ def main(args: Args) -> float:  # noqa: PLR0915
         pipeline.save(pipeline_filename, device=device)
         print(f"[INFO] Saved pipeline to {pipeline_filename}")
         save_checkpoint_package(
-            checkpoint_backend=args.checkpoint_backend,
+            checkpoint_backend="hf",
             hf_entity=args.hf_entity,
             hf_repo_prefix=args.hf_repo_prefix,
-            hf_private=args.hf_private,
+            hf_private=False,
             problem_id=args.problem_id,
             algo=args.algo,
             seed=args.seed,

--- a/engiopt/surrogate_model/run_pe_optimization.py
+++ b/engiopt/surrogate_model/run_pe_optimization.py
@@ -36,7 +36,6 @@ from pymoo.termination import get_termination
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_checkpoint_reference
 from engiopt.surrogate_model.model_pipeline import ModelPipeline
 from engiopt.surrogate_model.pymoo_pe_problem import PymooPowerElecProblem
@@ -61,8 +60,6 @@ class Args:
     # Optimisation hyperparameters
     seed: int
     """Random seed for the optimization, must match the seed used to train the models."""
-    model_source: ModelSource = "auto"
-    """Where to load the surrogate pipelines from."""
     pop_size: int = 500
     n_gen: int = 100
 
@@ -178,21 +175,19 @@ def save_front(res: Result, output_dir: str) -> tuple[str, str, str, str, str]:
 def load_model_from_reference(
     model_ref: str,
     *,
-    model_source: ModelSource,
     active_wandb_run: wandb.sdk.wandb_run.Run | None,
 ) -> ModelPipeline:
     """Load a model pipeline from a W&B artifact, HF package, or local directory.
 
     Args:
         model_ref: Reference to the stored model package or artifact.
-        model_source: Checkpoint backend to use when resolving the reference.
         active_wandb_run: Optional active W&B run for artifact access.
 
     Returns:
         Loaded model pipeline.
     """
     resolved = resolve_checkpoint_reference(
-        model_source=model_source,
+        model_source="auto",
         model_ref=model_ref,
         required_files=[],
         active_wandb_run=active_wandb_run,
@@ -224,12 +219,12 @@ def main(args: Args) -> None:
     active_wandb_run = wandb.run if args.track else None
     pipeline_g = load_model_from_reference(
         args.model_gain_path,
-        model_source=args.model_source,
+        model_source="auto",
         active_wandb_run=active_wandb_run,
     )
     pipeline_r = load_model_from_reference(
         args.model_ripple_path,
-        model_source=args.model_source,
+        model_source="auto",
         active_wandb_run=active_wandb_run,
     )
 

--- a/engiopt/surrogate_model/run_pe_optimization.py
+++ b/engiopt/surrogate_model/run_pe_optimization.py
@@ -219,12 +219,10 @@ def main(args: Args) -> None:
     active_wandb_run = wandb.run if args.track else None
     pipeline_g = load_model_from_reference(
         args.model_gain_path,
-        model_source="auto",
         active_wandb_run=active_wandb_run,
     )
     pipeline_r = load_model_from_reference(
         args.model_ripple_path,
-        model_source="auto",
         active_wandb_run=active_wandb_run,
     )
 

--- a/engiopt/vqgan/evaluate_vqgan.py
+++ b/engiopt/vqgan/evaluate_vqgan.py
@@ -12,7 +12,6 @@ import torch as th
 import tyro
 
 from engiopt import metrics
-from engiopt.checkpoint_store import ModelSource
 from engiopt.checkpoint_store import resolve_named_checkpoint
 from engiopt.dataset_sample_conditions import sample_conditions
 from engiopt.transforms import drop_constant
@@ -34,14 +33,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    model_source: ModelSource = "auto"
-    """Where to load the checkpoint package from."""
     hf_entity: str = "IDEALLab"
     """HF organization or user for checkpoint storage."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used to build per-family model repos."""
-    local_model_dir: str | None = None
-    """Optional local checkpoint package directory."""
     n_samples: int = 50
     """Number of generated samples per seed."""
     sigma: float = 10.0
@@ -72,7 +67,7 @@ if __name__ == "__main__":
     ### Set Up Transformer ###
 
     resolved = resolve_named_checkpoint(
-        model_source=args.model_source,
+        model_source="auto",
         problem_id=args.problem_id,
         algo="vqgan",
         seed=seed,
@@ -86,14 +81,13 @@ if __name__ == "__main__":
             "transformer.pth": f"{args.problem_id}_vqgan_transformer",
         },
         wandb_config_artifact_name=f"{args.problem_id}_vqgan_transformer",
-        local_model_dir=args.local_model_dir,
     )
     run_config = resolved.run_config
 
     ckpt_path_cvqgan = os.path.join(resolved.root_dir, "cvqgan.pth")
     if run_config["conditional"] and not os.path.exists(ckpt_path_cvqgan):
         cvqgan_resolved = resolve_named_checkpoint(
-            model_source="wandb" if args.model_source == "wandb" else "auto",
+            model_source="auto",
             problem_id=args.problem_id,
             algo="vqgan",
             seed=seed,
@@ -104,7 +98,6 @@ if __name__ == "__main__":
             wandb_entity=args.wandb_entity,
             wandb_artifact_names={"cvqgan.pth": f"{args.problem_id}_vqgan_cvqgan"},
             wandb_config_artifact_name=f"{args.problem_id}_vqgan_transformer",
-            local_model_dir=args.local_model_dir,
         )
         ckpt_path_cvqgan = cvqgan_resolved.files["cvqgan.pth"]
 

--- a/engiopt/vqgan/vqgan.py
+++ b/engiopt/vqgan/vqgan.py
@@ -1000,7 +1000,6 @@ if __name__ == "__main__":
                             run_config=vars(args),
                             metadata={"stage": "cvqgan"},
                             primary_files=["cvqgan.pth"],
-                            wandb_artifacts={f"{args.problem_id}_{args.algo}_cvqgan": "cvqgan.pth"},
                         )
 
         # Freeze CVQGAN for later use in Stage 2 Transformer
@@ -1120,10 +1119,6 @@ if __name__ == "__main__":
                         run_config=vars(args),
                         metadata={"stage": "vqgan"},
                         primary_files=["vqgan.pth"],
-                        wandb_artifacts={
-                            f"{args.problem_id}_{args.algo}_vqgan": "vqgan.pth",
-                            f"{args.problem_id}_{args.algo}_discriminator": "discriminator.pth",
-                        },
                     )
 
     # Freeze VQGAN for later use in Stage 2 Transformer
@@ -1265,7 +1260,6 @@ if __name__ == "__main__":
             run_config=vars(args),
             metadata={"stage": "transformer"},
             primary_files=["transformer.pth"],
-            wandb_artifacts={f"{args.problem_id}_{args.algo}_transformer": "transformer.pth"},
         )
 
     wandb.finish()

--- a/engiopt/vqgan/vqgan.py
+++ b/engiopt/vqgan/vqgan.py
@@ -32,7 +32,6 @@ import tqdm
 import tyro
 import wandb
 
-from engiopt.checkpoint_store import CheckpointBackend
 from engiopt.checkpoint_store import save_checkpoint_package
 from engiopt.reproducibility import enable_strict_determinism
 from engiopt.reproducibility import make_dataloader_generator
@@ -70,14 +69,10 @@ class Args:
     """Wandb project name."""
     wandb_entity: str | None = None
     """Wandb entity name."""
-    checkpoint_backend: CheckpointBackend = "hf"
-    """Checkpoint backend for saved models."""
     hf_entity: str = "IDEALLab"
     """HF organization or user for checkpoint storage."""
     hf_repo_prefix: str = "engiopt"
     """HF repo prefix used to build per-family model repos."""
-    hf_private: bool = False
-    """Whether newly created HF repos should be private."""
     seed: int = 1
     """Random seed."""
 
@@ -989,10 +984,10 @@ if __name__ == "__main__":
 
                         th.save(ckpt_cvq, "cvqgan.pth")
                         save_checkpoint_package(
-                            checkpoint_backend=args.checkpoint_backend,
+                            checkpoint_backend="hf",
                             hf_entity=args.hf_entity,
                             hf_repo_prefix=args.hf_repo_prefix,
-                            hf_private=args.hf_private,
+                            hf_private=False,
                             problem_id=args.problem_id,
                             algo=args.algo,
                             seed=args.seed,
@@ -1105,10 +1100,10 @@ if __name__ == "__main__":
                     th.save(ckpt_vq, "vqgan.pth")
                     th.save(ckpt_disc, "discriminator.pth")
                     save_checkpoint_package(
-                        checkpoint_backend=args.checkpoint_backend,
+                        checkpoint_backend="hf",
                         hf_entity=args.hf_entity,
                         hf_repo_prefix=args.hf_repo_prefix,
-                        hf_private=args.hf_private,
+                        hf_private=False,
                         problem_id=args.problem_id,
                         algo=args.algo,
                         seed=args.seed,
@@ -1249,10 +1244,10 @@ if __name__ == "__main__":
             checkpoint_files["cvqgan.pth"] = "cvqgan.pth"
 
         save_checkpoint_package(
-            checkpoint_backend=args.checkpoint_backend,
+            checkpoint_backend="hf",
             hf_entity=args.hf_entity,
             hf_repo_prefix=args.hf_repo_prefix,
-            hf_private=args.hf_private,
+            hf_private=False,
             problem_id=args.problem_id,
             algo=args.algo,
             seed=args.seed,


### PR DESCRIPTION
## Summary

Stacks on #63 to deliver the policy we agreed on: **HuggingFace is the only place model checkpoints are stored. W&B continues to handle scalars, media, and run history.**

## What the new UX looks like

**One-time setup:**

```
wandb login
huggingface-cli login   # or: export HF_TOKEN=...
```

**Training:**

```
python engiopt/cgan_cnn_2d/cgan_cnn_2d.py --problem-id beams2d --seed 1 --track --save-model
```

- `--track` logs scalars + media to W&B (default project: `engiopt`)
- `--save-model` uploads the checkpoint to HF (default repo: `IDEALLab/engiopt-cgan-cnn-2d`)
- Override `--hf-entity` / `--hf-repo-prefix` for personal experiments — same shape as `--wandb-entity` / `--wandb-project`

**Evaluation / inference:**

```
python engiopt/cgan_cnn_2d/evaluate_cgan_cnn_2d.py --problem-id beams2d --seed 1
```

- Pulls the checkpoint from HF automatically
- Falls back silently to the legacy W&B artifact for runs trained before this cutover

## Flags removed (cleanup)

These flags from #63 are no longer surfaced to users; behavior is folded into sensible defaults:

| Removed flag | New behavior |
|---|---|
| `--checkpoint-backend` | Always HF. `--save-model` is the on/off. |
| `--hf-private` | Always public. Create a private repo manually if needed. |
| `--model-source` | Always auto: HF first, W&B fallback. |
| `--local-model-dir` | Power-user knob; can be re-added later. |

The W&B read fallback inside `checkpoint_store.py` stays as a safety net while existing artifacts are still on W&B. A later cleanup PR will remove it once everything is migrated.

## What's verified

- HF train → eval round-trip on `beams2d` / `cgan_cnn_2d` (1 epoch, seed 999):
  - Checkpoint uploaded to `IDEALLab/engiopt-cgan-cnn-2d/beams2d/seed_999/`
  - Immutable run-scoped path `…/seed_999/run_<wandb_run_id>/` also created
  - W&B run summary recorded the HF repo, package path, and revision
  - Eval auto-pulled the checkpoint, ran inference, wrote the metrics CSV
  - Test artifacts deleted afterward
- CI: ruff, pre-commit, mypy all green

## Forward-compat for the upcoming LVAE work

The future LVAE-minimal branch saves with custom subpaths (`rec{r}/perf{p}/{filter}/seed_{s}`) and reads legacy W&B artifacts under the LVAE alias scheme (`seed_{s}_rec{r}_perf{p}…`). Both hooks — `extra_path_parts` and `wandb_artifact_alias` — are already wired into `save_checkpoint_package` and `resolve_named_checkpoint`, so the LVAE migration is per-script editing only. No further changes to `checkpoint_store.py` are needed.

## Commits

1. **HF-only writes, configurable W&B read alias** — drop the `"wandb"`/`"both"` write modes; add `wandb_artifact_alias` so legacy reads work for non-standard alias schemes.
2. **Collapse CLI surface to W&B parallel** — drop the 4 flags listed above; bake their old defaults into the call sites.
3. **mypy fix** — drop two now-invalid `model_source=` kwargs on `load_model_from_reference` call sites that the earlier flag cleanup left behind.
